### PR TITLE
Added warning for broken pytorch version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If PANet is useful for your research, please consider citing:
 
 For environment requirements, data preparation and compilation, please refer to [Detectron.pytorch](https://github.com/roytseng-tw/Detectron.pytorch).
 
+WARNING: pytorch 0.4.1 is broken, see https://github.com/pytorch/pytorch/issues/8483. Use pytorch 0.4.0
+
 ### Usage
 
 For training and testing, we keep the same as the one in [Detectron.pytorch](https://github.com/roytseng-tw/Detectron.pytorch). To train and test PANet, simply use corresponding config files. For example, to train PANet on COCO:


### PR DESCRIPTION
Due to an issue in the 0.4.1 version of pytorch, the make.sh script cannot be run successful. Until this is fixed, a warning should be displayed. 